### PR TITLE
fix: Fix calling Rate class in the Add action

### DIFF
--- a/Controller/Adminhtml/Index/Add.php
+++ b/Controller/Adminhtml/Index/Add.php
@@ -104,6 +104,7 @@ class Add extends Action
             0,
             $code,
             $country,
+            '*',
             $percentage
         );
 


### PR DESCRIPTION
Provide an extra value for the postcode for the Rate class in the Add action.
This fix solves the exception on adding selected tax rate.